### PR TITLE
Adopt plugins to J4

### DIFF
--- a/plugins/content/jcomments.xml
+++ b/plugins/content/jcomments.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="2.5" type="plugin" group="content" method="upgrade">
+<extension type="plugin" group="content" method="upgrade">
 	<name>plg_content_jcomments</name>
 	<creationDate>15/08/2018</creationDate>
 	<author>smart</author>
@@ -7,7 +7,7 @@
 	<authorEmail>smart@joomlatune.ru</authorEmail>
 	<authorUrl>http://www.joomlatune.ru</authorUrl>
 	<license>http://www.gnu.org/copyleft/gpl.html GNU/GPL</license>
-	<version>1.0</version>
+	<version>2.0</version>
 	<description>PLG_CONTENT_JCOMMENTS_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="jcomments">jcomments.php</filename>

--- a/plugins/editors-xtd/jcommentsoff/jcommentsoff.php
+++ b/plugins/editors-xtd/jcommentsoff/jcommentsoff.php
@@ -11,41 +11,54 @@
 
 defined('_JEXEC') or die;
 
-jimport('joomla.plugin.plugin');
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\Plugin\CMSPlugin;
 
 /**
  * Provides button to insert {jcomments off} into content edit box
+ *
+ * @since  1.5
  */
-class plgButtonJCommentsOff extends JPlugin
+class plgButtonJCommentsOff extends CMSPlugin
 {
-	public function __construct(& $subject, $config)
+	protected $autoloadLanguage = true;
+
+	public function __construct(&$subject, $config)
 	{
 		parent::__construct($subject, $config);
-		$this->loadLanguage('plg_editors-xtd_jcommentsoff', JPATH_ADMINISTRATOR);
+		$this->loadLanguage('plg_editors-xtd_jcommentson', JPATH_ADMINISTRATOR);
 	}
 
-	function onDisplay($name)
+	/**
+	 * JComments Off button
+	 *
+	 * @param string $name Editor field name
+	 *
+	 * @return  CMSObject  $button
+	 *
+	 * @throws  Exception
+	 * @since   1.5
+	 */
+	public function onDisplay($name)
 	{
-		$getContent = $this->_subject->getContent($name);
 		$js = "
-				function insertJCommentsOff(editor) {
-					var content = $getContent
-					if (content.match(/{jcomments off}/)) {
-						return false;
-					} else {
-						jInsertEditorText('{jcomments off}', editor);
-					}
-				}
-				";
+		function insertJCommentsOff(editor) {
+			var content = Joomla.editors.instances['$name'].getValue();
 
-		$document = JFactory::getDocument();
-		$document->addScriptDeclaration($js);
+			if (!content.match(/{jcomments off}/)) {
+				Joomla.editors.instances['$name'].replaceSelection('{jcomments off}');
+			}
+		}";
 
-		$button = new JObject();
+		Factory::getApplication()->getDocument()->addScriptDeclaration($js);
+
+		$button = new CMSObject();
 		$button->set('class', 'btn');
 		$button->set('modal', false);
 		$button->set('onclick', 'insertJCommentsOff(\'' . $name . '\');return false;');
-		$button->set('text', JText::_('PLG_EDITORS-XTD_JCOMMENTSOFF_BUTTON_JCOMMENTSOFF'));
+		$button->set('text', Text::_('PLG_EDITORS-XTD_JCOMMENTSOFF_BUTTON_JCOMMENTSOFF'));
 		$button->set('name', 'blank');
 		$button->set('link', '#');
 

--- a/plugins/editors-xtd/jcommentsoff/jcommentsoff.xml
+++ b/plugins/editors-xtd/jcommentsoff/jcommentsoff.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="2.5" type="plugin" group="editors-xtd" method="upgrade">
+<extension type="plugin" group="editors-xtd" method="upgrade">
 	<name>plg_editors-xtd_jcommentsoff</name>
 	<creationDate>15/08/2018</creationDate>
 	<author>smart</author>
@@ -7,7 +7,7 @@
 	<authorEmail>smart@joomlatune.ru</authorEmail>
 	<authorUrl>http://www.joomlatune.ru</authorUrl>
 	<license>http://www.gnu.org/copyleft/gpl.html GNU/GPL</license>
-	<version>1.0</version>
+	<version>2.0</version>
 	<description>PLG_EDITORS-XTD_JCOMMENTSOFF_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="jcommentsoff">jcommentsoff.php</filename>

--- a/plugins/editors-xtd/jcommentson/jcommentson.php
+++ b/plugins/editors-xtd/jcommentson/jcommentson.php
@@ -11,41 +11,54 @@
 
 defined('_JEXEC') or die;
 
-jimport('joomla.plugin.plugin');
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\Plugin\CMSPlugin;
 
 /**
  * Provides button to insert {jcomments on} into content edit box
+ *
+ * @since  1.5
  */
-class plgButtonJCommentsOn extends JPlugin
+class plgButtonJCommentsOn extends CMSPlugin
 {
-	public function __construct(& $subject, $config)
+	protected $autoloadLanguage = true;
+
+	public function __construct(&$subject, $config)
 	{
 		parent::__construct($subject, $config);
 		$this->loadLanguage('plg_editors-xtd_jcommentson', JPATH_ADMINISTRATOR);
 	}
 
-	function onDisplay($name)
+	/**
+	 * JComments On button
+	 *
+	 * @param string $name Editor field name
+	 *
+	 * @return  CMSObject  $button
+	 *
+	 * @throws  Exception
+	 * @since   1.5
+	 */
+	public function onDisplay($name)
 	{
-		$getContent = $this->_subject->getContent($name);
 		$js = "
-				function insertJCommentsOn(editor) {
-					var content = $getContent
-					if (content.match(/{jcomments on}/)) {
-						return false;
-					} else {
-						jInsertEditorText('{jcomments on}', editor);
-					}
-				}
-				";
+		function insertJCommentsOn(editor) {
+			var content = Joomla.editors.instances['$name'].getValue();
 
-		$document = JFactory::getDocument();
-		$document->addScriptDeclaration($js);
+			if (!content.match(/{jcomments on}/)) {
+				Joomla.editors.instances['$name'].replaceSelection('{jcomments on}');
+			}
+		}";
 
-		$button = new JObject();
+		Factory::getApplication()->getDocument()->addScriptDeclaration($js);
+
+		$button = new CMSObject();
 		$button->set('class', 'btn');
 		$button->set('modal', false);
 		$button->set('onclick', 'insertJCommentsOn(\'' . $name . '\');return false;');
-		$button->set('text', JText::_('PLG_EDITORS-XTD_JCOMMENTSON_BUTTON_JCOMMENTSON'));
+		$button->set('text', Text::_('PLG_EDITORS-XTD_JCOMMENTSON_BUTTON_JCOMMENTSON'));
 		$button->set('name', 'blank');
 		$button->set('link', '#');
 

--- a/plugins/editors-xtd/jcommentson/jcommentson.xml
+++ b/plugins/editors-xtd/jcommentson/jcommentson.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="2.5" type="plugin" group="editors-xtd" method="upgrade">
+<extension type="plugin" group="editors-xtd" method="upgrade">
 	<name>plg_editors-xtd_jcommentson</name>
 	<creationDate>15/08/2018</creationDate>
 	<author>smart</author>
@@ -7,7 +7,7 @@
 	<authorEmail>smart@joomlatune.ru</authorEmail>
 	<authorUrl>http://www.joomlatune.ru</authorUrl>
 	<license>http://www.gnu.org/copyleft/gpl.html GNU/GPL</license>
-	<version>1.0</version>
+	<version>2.0</version>
 	<description>PLG_EDITORS-XTD_JCOMMENTSON_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="jcommentson">jcommentson.php</filename>

--- a/plugins/quickicon/jcomments.php
+++ b/plugins/quickicon/jcomments.php
@@ -11,36 +11,43 @@
 
 defined('_JEXEC') or die;
 
-class plgQuickiconJComments extends JPlugin
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Plugin\CMSPlugin;
+
+class plgQuickiconJComments extends CMSPlugin
 {
 	public function onGetIcons($context)
 	{
-		if ($context == $this->params->get('context', 'mod_quickicon') 
-		&& JFactory::getUser()->authorise('core.manage', 'com_jcomments')) {
+		$app = Factory::getApplication();
 
-			JFactory::getLanguage()->load('com_jcomments.sys', JPATH_ADMINISTRATOR, 'en-GB', true);
+		if ($context == $this->params->get('context', 'mod_quickicon')
+			&& $app->getIdentity()->authorise('core.manage', 'com_jcomments'))
+		{
+
+			$app->getLanguage()->load('com_jcomments.sys', JPATH_ADMINISTRATOR, 'en-GB', true);
 			$this->loadLanguage('com_jcomments.sys', JPATH_ADMINISTRATOR);
 
 			$text = $this->params->get('displayedtext');
-			if (empty($text)) {
-				$text = JText::_('COM_JCOMMENTS');
+
+			if (empty($text))
+			{
+				$text = Text::_('COM_JCOMMENTS');
 			}
 
-			if (version_compare(JVERSION, '3.0', '>')) {
-				$image = 'comments';
-			} else {
-				$image = JURI::base().'components/com_jcomments/assets/images/icon-48-jcomments.png';
-			}
-			
 			return array(
 				array(
-					'link' => 'index.php?option=com_jcomments',
-					'image' => $image,
-					'text' => $text,
+					'link'   => 'index.php?option=com_jcomments',
+					'image'  => 'comments',
+					'text'   => $text,
 					'access' => array('core.manage', 'com_jcomments'),
-					'id' => 'plg_quickicon_jcomments'
-					)
-				);
+					'id'     => 'plg_quickicon_jcomments'
+				)
+			);
+		}
+		else
+		{
+			return array();
 		}
 	}
 }

--- a/plugins/quickicon/jcomments.xml
+++ b/plugins/quickicon/jcomments.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="2.5" type="plugin" group="quickicon" method="upgrade">
+<extension type="plugin" group="quickicon" method="upgrade">
 	<name>plg_quickicon_jcomments</name>
 	<creationDate>15/08/2018</creationDate>
 	<author>smart</author>
@@ -7,7 +7,7 @@
 	<authorEmail>smart@joomlatune.ru</authorEmail>
 	<authorUrl>http://www.joomlatune.ru</authorUrl>
 	<license>http://www.gnu.org/copyleft/gpl.html GNU/GPL</license>
-	<version>1.0</version>
+	<version>2.0</version>
 	<description>PLG_QUICKICON_JCOMMENTS_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="jcomments">jcomments.php</filename>

--- a/plugins/search/jcomments.php
+++ b/plugins/search/jcomments.php
@@ -2,33 +2,36 @@
 /**
  * JComments - Joomla Comment System
  *
- * @version 3.0
- * @package JComments
- * @author Sergey M. Litvinov (smart@joomlatune.ru)
+ * @version       3.0
+ * @package       JComments
+ * @author        Sergey M. Litvinov (smart@joomlatune.ru)
  * @copyright (C) 2006-2013 by Sergey M. Litvinov (http://www.joomlatune.ru)
- * @license GNU/GPL: http://www.gnu.org/copyleft/gpl.html
+ * @license       GNU/GPL: http://www.gnu.org/copyleft/gpl.html
  */
 
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\String\StringHelper;
 
-jimport('joomla.plugin.plugin');
 include_once(JPATH_ROOT . '/components/com_jcomments/jcomments.legacy.php');
 
 /**
  * Search plugin
+ *
+ * @since 1.5
  */
-class plgSearchJComments extends JPlugin
+class plgSearchJComments extends CMSPlugin
 {
 	/**
 	 * Constructor
 	 *
-	 * @param object $subject The object to observe
-	 * @param array $config  An array that holds the plugin configuration
+	 * @param   object  $subject  The object to observe
+	 * @param   array   $config   An array that holds the plugin configuration
 	 */
-	public function __construct(& $subject, $config)
+	public function __construct(&$subject, $config)
 	{
 		parent::__construct($subject, $config);
 		$this->loadLanguage('plg_search_jcomments', JPATH_SITE);
@@ -37,7 +40,7 @@ class plgSearchJComments extends JPlugin
 	/**
 	 * @return array An array of search areas
 	 */
-	function onContentSearchAreas()
+	public function onContentSearchAreas()
 	{
 		static $areas = array('comments' => 'PLG_SEARCH_JCOMMENTS_COMMENTS');
 
@@ -47,58 +50,66 @@ class plgSearchJComments extends JPlugin
 	/**
 	 * Comments Search method
 	 *
-	 * @param string $text Target search string
-	 * @param string $phrase mathcing option, exact|any|all
-	 * @param string $ordering ordering option, newest|oldest|popular|alpha|category
-	 * @param mixed $areas An array if the search it to be restricted to areas, null if search all
+	 * @param   string  $text      Target search string
+	 * @param   string  $phrase    mathcing option, exact|any|all
+	 * @param   string  $ordering  ordering option, newest|oldest|popular|alpha|category
+	 * @param   mixed   $areas     An array if the search it to be restricted to areas, null if search all
+	 *
 	 * @return array
 	 */
-	function onContentSearch($text, $phrase = '', $ordering = '', $areas = null)
+	public function onContentSearch($text, $phrase = '', $ordering = '', $areas = null)
 	{
-		$text = StringHelper::strtolower(trim($text));
+		$text   = StringHelper::strtolower(trim($text));
 		$result = array();
 
-		if ($text == '' || !defined('JCOMMENTS_JVERSION')) {
+		if ($text == '' || !defined('JCOMMENTS_JVERSION'))
+		{
 			return $result;
 		}
 
-		if (is_array($areas)) {
-			if (!array_intersect($areas, array_keys($this->onContentSearchAreas()))) {
+		if (is_array($areas))
+		{
+			if (!array_intersect($areas, array_keys($this->onContentSearchAreas())))
+			{
 				return $result;
 			}
 		}
-		if (file_exists(JPATH_ROOT . '/components/com_jcomments/jcomments.php')) {
+		if (file_exists(JPATH_ROOT . '/components/com_jcomments/jcomments.php'))
+		{
 			require_once(JPATH_ROOT . '/components/com_jcomments/jcomments.php');
 
-			$db = Factory::getContainer()->get('DatabaseDriver');
+			$db    = Factory::getContainer()->get('DatabaseDriver');
 			$limit = $this->params->def('search_limit', 50);
 
-			switch ($phrase) {
+			switch ($phrase)
+			{
 				case 'exact':
-					$text = $db->Quote('%' . $db->escape($text, true) . '%', false);
+					$text      = $db->Quote('%' . $db->escape($text, true) . '%', false);
 					$wheres2[] = "LOWER(c.name) LIKE " . $text;
 					$wheres2[] = "LOWER(c.comment) LIKE " . $text;
 					$wheres2[] = "LOWER(c.title) LIKE " . $text;
-					$where = '(' . implode(') OR (', $wheres2) . ')';
+					$where     = '(' . implode(') OR (', $wheres2) . ')';
 					break;
 				case 'all':
 				case 'any':
 				default:
-					$words = explode(' ', $text);
+					$words  = explode(' ', $text);
 					$wheres = array();
-					foreach ($words as $word) {
-						$word = $db->Quote('%' . $db->escape($word, true) . '%', false);
-						$wheres2 = array();
+					foreach ($words as $word)
+					{
+						$word      = $db->Quote('%' . $db->escape($word, true) . '%', false);
+						$wheres2   = array();
 						$wheres2[] = "LOWER(c.name) LIKE " . $word;
 						$wheres2[] = "LOWER(c.comment) LIKE " . $word;
 						$wheres2[] = "LOWER(c.title) LIKE " . $word;
-						$wheres[] = implode(' OR ', $wheres2);
+						$wheres[]  = implode(' OR ', $wheres2);
 					}
 					$where = '(' . implode(($phrase == 'all' ? ') AND (' : ') OR ('), $wheres) . ')';
 					break;
 			}
 
-			switch ($ordering) {
+			switch ($ordering)
+			{
 				case 'oldest':
 					$order = 'c.date ASC';
 					break;
@@ -109,20 +120,23 @@ class plgSearchJComments extends JPlugin
 			}
 
 
-			$acl = JCommentsFactory::getACL();
+			$acl    = JCommentsFactory::getACL();
 			$access = $acl->getUserAccess();
 
-			if (is_array($access)) {
+			if (is_array($access))
+			{
 				$accessCondition = "AND jo.access IN (" . implode(',', $access) . ")";
-			} else {
-				$accessCondition = "AND jo.access <= " . (int)$access;
+			}
+			else
+			{
+				$accessCondition = "AND jo.access <= " . (int) $access;
 			}
 
 			$query = "SELECT "
 				. "  c.comment AS text"
 				. ", c.date AS created"
 				. ", '2' AS browsernav"
-				. ", '" . JText::_('PLG_SEARCH_JCOMMENTS_COMMENTS') . "' AS section"
+				. ", '" . Text::_('PLG_SEARCH_JCOMMENTS_COMMENTS') . "' AS section"
 				. ", ''  AS href"
 				. ", c.id"
 				. ", jo.title AS object_title, jo.link AS object_link"
@@ -141,27 +155,32 @@ class plgSearchJComments extends JPlugin
 
 			$cnt = count($rows);
 
-			if ($cnt > 0) {
-				$config = JCommentsFactory::getConfig();
-				$enableCensor = $acl->check('enable_autocensor');
+			if ($cnt > 0)
+			{
+				$config         = JCommentsFactory::getConfig();
+				$enableCensor   = $acl->check('enable_autocensor');
 				$word_maxlength = $config->getInt('word_maxlength');
 
-				for ($i = 0; $i < $cnt; $i++) {
+				for ($i = 0; $i < $cnt; $i++)
+				{
 					$text = JCommentsText::cleanText($rows[$i]->text);
 
-					if ($enableCensor) {
+					if ($enableCensor)
+					{
 						$text = JCommentsText::censor($text);
 					}
 
-					if ($word_maxlength > 0) {
+					if ($word_maxlength > 0)
+					{
 						$text = JCommentsText::fixLongWords($text, $word_maxlength);
 					}
 
-					if ($text != '') {
+					if ($text != '')
+					{
 						$rows[$i]->title = $rows[$i]->object_title;
-						$rows[$i]->text = $text;
-						$rows[$i]->href = $rows[$i]->object_link . '#comment-' . $rows[$i]->id;
-						$result[] = $rows[$i];
+						$rows[$i]->text  = $text;
+						$rows[$i]->href  = $rows[$i]->object_link . '#comment-' . $rows[$i]->id;
+						$result[]        = $rows[$i];
 					}
 				}
 			}
@@ -171,12 +190,12 @@ class plgSearchJComments extends JPlugin
 		return $result;
 	}
 
-	function onSearchAreas()
+	public function onSearchAreas()
 	{
 		return $this->onContentSearchAreas();
 	}
 
-	function onSearch($text, $phrase = '', $ordering = '', $areas = null)
+	public function onSearch($text, $phrase = '', $ordering = '', $areas = null)
 	{
 		return $this->onContentSearch($text, $phrase, $ordering, $areas);
 	}

--- a/plugins/search/jcomments.xml
+++ b/plugins/search/jcomments.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="2.5" type="plugin" group="search" method="upgrade">
+<extension type="plugin" group="search" method="upgrade">
 	<name>plg_search_jcomments</name>
 	<creationDate>15/08/2018</creationDate>
 	<author>smart</author>
@@ -7,7 +7,7 @@
 	<authorEmail>smart@joomlatune.ru</authorEmail>
 	<authorUrl>http://www.joomlatune.ru</authorUrl>
 	<license>http://www.gnu.org/copyleft/gpl.html GNU/GPL</license>
-	<version>1.0</version>
+	<version>2.0</version>
 	<description>PLG_SEARCH_JCOMMENTS_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="jcomments">jcomments.php</filename>

--- a/plugins/system/jcomments.php
+++ b/plugins/system/jcomments.php
@@ -2,108 +2,117 @@
 /**
  * JComments - Joomla Comment System
  *
- * @version 3.0
- * @package JComments
- * @author Sergey M. Litvinov (smart@joomlatune.ru)
+ * @version       3.0
+ * @package       JComments
+ * @author        Sergey M. Litvinov (smart@joomlatune.ru)
  * @copyright (C) 2006-2013 by Sergey M. Litvinov (http://www.joomlatune.ru)
- * @license GNU/GPL: http://www.gnu.org/copyleft/gpl.html
+ * @license       GNU/GPL: http://www.gnu.org/copyleft/gpl.html
  */
-
-use Joomla\Utilities\ArrayHelper;
 
 defined('_JEXEC') or die;
 
-jimport('joomla.plugin.plugin');
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\Utilities\ArrayHelper;
+
 define('JCOMMENTS_SITE', JPATH_ROOT . '/components/com_jcomments');
 define('JCOMMENTS_HELPERS', JCOMMENTS_SITE . '/helpers');
 include_once(JCOMMENTS_HELPERS . '/system.php');
 
 /**
  * System plugin for attaching JComments CSS & JavaScript to HEAD tag
+ *
+ * @since 1.5
  */
-class plgSystemJComments extends JPlugin
+class plgSystemJComments extends CMSPlugin
 {
 	/**
 	 * Constructor
 	 *
-	 * @param object $subject The object to observe
-	 * @param array $config  An array that holds the plugin configuration
+	 * @param   object  $subject  The object to observe
+	 * @param   array   $config   An array that holds the plugin configuration
+	 *
+	 * @throws Exception
+	 * @since 1.5
 	 */
 	public function __construct(&$subject, $config)
 	{
 		parent::__construct($subject, $config);
 
-		if (!isset($this->params)) {
+		if (!isset($this->params))
+		{
 			$this->params = new JRegistry('');
 		}
 
 		// small hack to allow CAPTCHA display even if any notice or warning occurred
-		$app = JFactory::getApplication('site');
+		$app    = Factory::getApplication();
 		$option = $app->input->get('option');
-		$task = $app->input->get('task');
-		if ($option == 'com_jcomments' && $task == 'captcha') {
+		$task   = $app->input->get('task');
+
+		if ($option == 'com_jcomments' && $task == 'captcha')
+		{
 			@ob_start();
 		}
 
-		if (isset($_REQUEST['jtxf'])) {
-			if ($this->params->get('disable_error_reporting', 0) == 1) {
+		if (isset($_REQUEST['jtxf']))
+		{
+			if ($this->params->get('disable_error_reporting', 0) == 1)
+			{
 				// turn off all error reporting for AJAX call
 				@error_reporting(E_NONE);
 			}
 		}
 	}
 
-
-
-
-
-	function onAfterRender()
+	public function onAfterRender()
 	{
-		$app = JFactory::getApplication();
-		if ($this->params->get('clear_rss', 0) == 1) {
+		$app    = Factory::getApplication();
+		$buffer = $app->getBody();
+
+		if ($this->params->get('clear_rss', 0) == 1)
+		{
 			$option = $app->input->get('option');
-			if ($option == 'com_content') {
-				$document = JFactory::getDocument();
-				if ($document->getType() == 'feed') {
-					$buffer = JResponse::getBody();
+
+			if ($option == 'com_content')
+			{
+				$document = Factory::getDocument();
+
+				if ($document->getType() == 'feed')
+				{
 					$buffer = preg_replace('#{jcomments\s+(off|on|lock)}#is', '', $buffer);
-					JResponse::setBody($buffer);
+					$app->setBody($buffer);
 				}
 			}
 		}
 
-		if ((defined('JCOMMENTS_CSS') || defined('JCOMMENTS_JS')) && !defined('JCOMMENTS_SHOW')) {
-			if ($app->getName() == 'site') {
-				if (version_compare(JVERSION, '4.0', 'lt')){
-					$buffer = JResponse::getBody();
-				} else {
-					$buffer = $app->getBody();
-				}
-				$regexpJS = '#(\<script(\stype=\"text\/javascript\")? src="[^\"]*\/com_jcomments\/[^\>]*\>\<\/script\>[\s\r\n]*?)#ismU';
+		if ((defined('JCOMMENTS_CSS') || defined('JCOMMENTS_JS')) && !defined('JCOMMENTS_SHOW'))
+		{
+			if ($app->getName() == 'site')
+			{
+				$regexpJS  = '#(\<script(\stype=\"text\/javascript\")? src="[^\"]*\/com_jcomments\/[^\>]*\>\<\/script\>[\s\r\n]*?)#ismU';
 				$regexpCSS = '#(\<link rel="stylesheet" href="[^\"]*\/com_jcomments\/[^>]*>[\s\r\n]*?)#ismU';
 
-				$jcommentsTestJS = '#(JCommentsEditor|new JComments)#ismU';
+				$jcommentsTestJS  = '#(JCommentsEditor|new JComments)#ismU';
 				$jcommentsTestCSS = '#(comment-link|jcomments-links)#ismU';
 
-				$jsFound = preg_match($jcommentsTestJS, $buffer);
+				$jsFound  = preg_match($jcommentsTestJS, $buffer);
 				$cssFound = preg_match($jcommentsTestCSS, $buffer);
 
-				if (!$jsFound) {
+				if (!$jsFound)
+				{
 					// remove JavaScript if JComments isn't loaded
 					$buffer = preg_replace($regexpJS, '', $buffer);
 				}
 
-				if (!$cssFound && !$jsFound) {
+				if (!$cssFound && !$jsFound)
+				{
 					// remove CSS if JComments isn't loaded
 					$buffer = preg_replace($regexpCSS, '', $buffer);
 				}
 
-				if ($buffer != '') {
-					if (version_compare(JVERSION, '4.0', 'lt')){
-						JResponse::setBody($buffer);
-					} else {
-						$app->setBody($buffer);
-					}
+				if ($buffer != '')
+				{
+					$app->setBody($buffer);
 				}
 			}
 		}
@@ -111,75 +120,85 @@ class plgSystemJComments extends JPlugin
 		return true;
 	}
 
-	function onAfterRoute()
+	public function onAfterRoute()
 	{
 		$legacyFile = JPATH_ROOT . '/components/com_jcomments/jcomments.legacy.php';
 
-		if (!is_file($legacyFile)) {
+		if (!is_file($legacyFile))
+		{
 			return;
 		}
 
 		include_once($legacyFile);
 
-		$app = JFactory::getApplication('site');
+		$app = Factory::getApplication();
 		$app->getRouter();
-		$document = JFactory::getDocument();
+		$document = Factory::getDocument();
 
-		if ($document->getType() == 'html') {
-			if (JCommentsSystemPluginHelper::isAdmin($app)) {
+		if ($document->getType() == 'html')
+		{
+			if (JCommentsSystemPluginHelper::isAdmin($app))
+			{
 				$document->addStyleSheet(JURI::root(true) . '/administrator/components/com_jcomments/assets/css/icon.css?v=2');
-				JFactory::getLanguage()->load('com_jcomments.sys', JPATH_ROOT . '/administrator', 'en-GB', true);
-				if (version_compare(JVERSION, '4.0', 'lt')){
-					$option = JAdministratorHelper::findOption();
-				} else {
-					$option = $app->findOption();
-				}
+				$app->getLanguage()->load('com_jcomments.sys', JPATH_ROOT . '/administrator', 'en-GB', true);
+
+				$option = $app->findOption();
 				$task = $app->input->get('task');
-				if (version_compare(JVERSION, '4.0', 'lt')){
-					//do not work in joomla 4					
-					$type = $app->input->post('type', '', 'post');
-				} else {
-					//to do find a better solution in joomla 4.0
-					$type = 'content';
-				}	
+
+				// TODO Do find a better solution in joomla 4.0
+				$type = 'content';
+
 				// remove comments if content item deleted from trash
-				if ($option == 'com_trash' && $task == 'delete' && $type == 'content') {
+				if ($option == 'com_trash' && $task == 'delete' && $type == 'content')
+				{
 					$cid = $app->input->post->get('cid', array(), 'array');
 					ArrayHelper::toInteger($cid, array(0));
 					include_once(JPATH_ROOT . '/components/com_jcomments/jcomments.php');
 					JCommentsModel::deleteComments($cid, 'com_content');
 				}
-			} else {
+			}
+			else
+			{
 				$option = $app->input->get('option');
 
-				if ($option == 'com_content' || $option == 'com_alphacontent' || $option == 'com_multicategories') {
+				if ($option == 'com_content' || $option == 'com_alphacontent' || $option == 'com_multicategories')
+				{
 					include_once(JPATH_ROOT . '/components/com_jcomments/jcomments.class.php');
 					include_once(JPATH_ROOT . '/components/com_jcomments/helpers/system.php');
 
 					// include JComments CSS
-					if ($this->params->get('disable_template_css', 0) == 0) {
+					if ($this->params->get('disable_template_css', 0) == 0)
+					{
 						$document->addStyleSheet(JCommentsSystemPluginHelper::getCSS());
-						$language = JFactory::getLanguage();
-						if ($language->isRTL()) {
+						$language = $app->getLanguage();
+
+						if ($language->isRTL())
+						{
 							$rtlCSS = JCommentsSystemPluginHelper::getCSS(true);
-							if ($rtlCSS != '') {
+
+							if ($rtlCSS != '')
+							{
 								$document->addStyleSheet($rtlCSS);
 							}
 						}
 					}
 
-					if (!defined('JCOMMENTS_CSS')) {
+					if (!defined('JCOMMENTS_CSS'))
+					{
 						define('JCOMMENTS_CSS', 1);
 					}
 
 					// include JComments JavaScript library
 					$document->addScript(JCommentsSystemPluginHelper::getCoreJS());
-					if (!defined('JOOMLATUNE_AJAX_JS')) {
+
+					if (!defined('JOOMLATUNE_AJAX_JS'))
+					{
 						$document->addScript(JCommentsSystemPluginHelper::getAjaxJS());
 						define('JOOMLATUNE_AJAX_JS', 1);
 					}
 
-					if (!defined('JCOMMENTS_JS')) {
+					if (!defined('JCOMMENTS_JS'))
+					{
 						define('JCOMMENTS_JS', 1);
 					}
 				}
@@ -188,21 +207,23 @@ class plgSystemJComments extends JPlugin
 	}
 
 
-	function onJCommentsShow($object_id, $object_group, $object_title)
+	public function onJCommentsShow($object_id, $object_group, $object_title)
 	{
 		$coreFile = JPATH_ROOT . '/components/com_jcomments/jcomments.php';
 
-		if (is_file($coreFile)) {
+		if (is_file($coreFile))
+		{
 			include_once($coreFile);
 			echo JComments::show($object_id, $object_group, $object_title);
 		}
 	}
 
-	function onJCommentsCount($object_id, $object_group)
+	public function onJCommentsCount($object_id, $object_group)
 	{
 		$coreFile = JPATH_ROOT . '/components/com_jcomments/jcomments.php';
 
-		if (is_file($coreFile)) {
+		if (is_file($coreFile))
+		{
 			include_once($coreFile);
 			echo JComments::getCommentsCount($object_id, $object_group);
 		}

--- a/plugins/system/jcomments.xml
+++ b/plugins/system/jcomments.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="2.5" type="plugin" group="system" method="upgrade">
+<extension type="plugin" group="system" method="upgrade">
 	<name>plg_system_jcomments</name>
 	<creationDate>15/08/2018</creationDate>
 	<author>smart</author>
@@ -7,7 +7,7 @@
 	<authorEmail>smart@joomlatune.ru</authorEmail>
 	<authorUrl>http://www.joomlatune.ru</authorUrl>
 	<license>http://www.gnu.org/copyleft/gpl.html GNU/GPL</license>
-	<version>1.0</version>
+	<version>2.0</version>
 	<description>PLG_SYSTEM_JCOMMENTS_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="jcomments">jcomments.php</filename>

--- a/plugins/user/jcomments.php
+++ b/plugins/user/jcomments.php
@@ -9,16 +9,17 @@
  * @license GNU/GPL: http://www.gnu.org/copyleft/gpl.html
  */
 
-use Joomla\CMS\Factory;
-
 defined('_JEXEC') or die;
 
-jimport('joomla.plugin.plugin');
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\CMSPlugin;
 
 /**
  * User plugin for updating user info in comments
+ *
+ * @since 1.5
  */
-class plgUserJComments extends JPlugin
+class plgUserJComments extends CMSPlugin
 {
 	function onUserAfterSave($user, $isNew, $success, $msg)
 	{

--- a/plugins/user/jcomments.xml
+++ b/plugins/user/jcomments.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="2.5" type="plugin" group="user" method="upgrade">
+<extension type="plugin" group="user" method="upgrade">
 	<name>plg_user_jcomments</name>
 	<creationDate>15/08/2018</creationDate>
 	<author>smart</author>
@@ -7,7 +7,7 @@
 	<authorEmail>smart@joomlatune.ru</authorEmail>
 	<authorUrl>http://www.joomlatune.ru</authorUrl>
 	<license>http://www.gnu.org/copyleft/gpl.html GNU/GPL</license>
-	<version>1.0</version>
+	<version>2.0</version>
 	<description>PLG_USER_JCOMMENTS_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="jcomments">jcomments.php</filename>


### PR DESCRIPTION
Fixed https://github.com/exstreme/Jcomments-4/issues/1
Remove extension version from plugin xml as it not necessary anymore.
Rise up plugin version.
Change old class names to new.
Applied Joomla code style.
Small code cleanup.