### PR TITLE
Update ajax.php Missing property - PHP 8.2.17

### DIFF
--- a/component/site/libraries/joomlatune/ajax.php
+++ b/component/site/libraries/joomlatune/ajax.php
@@ -149,6 +149,7 @@ if (!defined ('JOOMLATUNE_AJAX'))
 		var $aFunctions;
 		var $aObjects;
 		var $aFunctionRequestTypes;
+		var $aFunctionIncludeFiles;
 		var $sRequestURI;
 		var $sEncoding;
 


### PR DESCRIPTION
Missing property - PHP 8.2.17:
AH01071: Got error 'PHP message: PHP Deprecated: Creation of dynamic property JoomlaTuneAjax::$aFunctionIncludeFiles is deprecated in /components/com_jcomments/libraries/joomlatune/ajax.php on line 160'